### PR TITLE
remove outdated snow depth tiles with sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 #install prerequisites
 RUN apt-get -q update && \
-    apt-get -q -y install software-properties-common git python3.6 python3-pip \
-    build-essential unzip libsqlite3-dev zlib1g-dev wget curl && \
+    apt-get -q -y install awscli software-properties-common git python3.6 \
+    python3-pip build-essential unzip libsqlite3-dev zlib1g-dev wget curl && \
     add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     apt-get -q -y install gdal-bin gdal-data && \

--- a/code/download_data.sh
+++ b/code/download_data.sh
@@ -39,8 +39,14 @@ gdal_translate build/snow_depth.tiff build/snow_depth.mbtiles -co ZOOM_LEVEL_STR
 gdaladdo -r average build/snow_depth.mbtiles
 
 if [[ -v "S3_URL" ]]; then
+  aws s3 rm --recursive s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
   python3 /opt/Processing/upload_mbtiles.py --threads 100 \
       --extension ".png" \
       --header "Cache-Control:max-age=21600" \
-      build/snow_depth.mbtiles $S3_URL
+      build/snow_depth.mbtiles s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
+  aws s3 sync \
+      --delete
+      s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
+      $S3_URL
+  aws s3 rm --recursive s3://vectortiles-dev.gaiagps.com/us-snow-depth-raster/
 fi


### PR DESCRIPTION
By uploading to a staging bucket and using `aws s3 sync` we ensure that the production tiles are identical to the most recent generated tiles, including those that had existed in an older version but no longer exist in the most recent generated tiles. 

Closes https://github.com/trailbehind/MapStyles/issues/1109. 